### PR TITLE
Implement mining teams logic

### DIFF
--- a/public/index.php
+++ b/public/index.php
@@ -1,19 +1,37 @@
 <?php
 require __DIR__ . '/../vendor/autoload.php';
 
+session_start();
+
 use StationCommand\Core\Kernel;
 use StationCommand\Modules\ExampleModule\ExampleAgent;
 use StationCommand\Modules\ResourceModule\ResourceAgent;
 
 $kernel = new Kernel();
-$resourceAgent = new ResourceAgent();
+$resourceAgent = $_SESSION['resourceAgent'] ?? new ResourceAgent();
 $kernel->registerAgent($resourceAgent);
 $kernel->registerAgent(new ExampleAgent());
+
+$recruitMessage = '';
+if (isset($_POST['recruit'])) {
+    if ($resourceAgent->recruitTeam()) {
+        $recruitMessage = 'Recruited a new mining team.';
+    } else {
+        $recruitMessage = 'Not enough credits to recruit a mining team.';
+    }
+}
 
 ob_start();
 $kernel->runTick();
 $tickOutput = ob_get_clean();
+if ($recruitMessage !== '') {
+    $tickOutput = $recruitMessage."\n".$tickOutput;
+}
 $resources = $resourceAgent->getResources();
+$finances = $resourceAgent->getFinances();
+$miningTeams = $resourceAgent->getMiningTeams();
+
+$_SESSION['resourceAgent'] = $resourceAgent;
 ?>
 <!DOCTYPE html>
 <html lang="en">
@@ -31,7 +49,7 @@ $resources = $resourceAgent->getResources();
                     <span class="mr-2"><?= htmlspecialchars($name) ?>: <?= htmlspecialchars((string)$amount) ?></span>
                 <?php endforeach; ?>
             </div>
-            <div>Finances: <span id="finances">0</span></div>
+            <div>Finances: <span id="finances"><?= htmlspecialchars((string)$finances) ?></span></div>
         </div>
     </header>
     <div class="flex flex-1">
@@ -45,7 +63,14 @@ $resources = $resourceAgent->getResources();
         </aside>
         <main class="flex-1 bg-gray-700 p-4">
             <h2 class="text-lg font-bold mb-4">Station Overview</h2>
-            <div id="station-overview">Overview content here.</div>
+            <div id="station-overview">
+                <p>Mining Teams: <?= htmlspecialchars((string)$miningTeams) ?></p>
+                <form method="post" class="mt-2">
+                    <button type="submit" name="recruit" value="1" class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-1 px-2 rounded">
+                        Recruit Mining Team (<?= StationCommand\Modules\ResourceModule\ResourceAgent::TEAM_COST ?> cr)
+                    </button>
+                </form>
+            </div>
         </main>
         <aside class="w-1/5 bg-gray-800 p-4">
             <h2 class="text-lg font-bold mb-4">Defense & Security</h2>

--- a/src/Modules/ResourceModule/ResourceAgent.php
+++ b/src/Modules/ResourceModule/ResourceAgent.php
@@ -19,44 +19,72 @@ class ResourceAgent implements AgentInterface
         'uran_deuterium' => 50,
     ];
 
+    private int $miningTeams = 10;
+
+    private int $finances = 1000;
+
+    public const TEAM_COST = 100;
+
     public function tick(): void
     {
-        // Cost to run a mining expedition
         $cost = ['h2o' => 2];
-        foreach ($cost as $res => $amount) {
-            if ($this->resources[$res] < $amount) {
-                echo "Not enough {$res} to run mining expedition\n";
-                return;
+
+        for ($i = 0; $i < $this->miningTeams; $i++) {
+            foreach ($cost as $res => $amount) {
+                if ($this->resources[$res] < $amount) {
+                    echo "Not enough {$res} to run mining expedition\n";
+                    return;
+                }
             }
+            foreach ($cost as $res => $amount) {
+                $this->resources[$res] -= $amount;
+            }
+
+            $asteroidTypes = [
+                'iron',
+                'titan',
+                'silica',
+                'copper',
+                'water',
+                'uran_deuterium',
+            ];
+
+            $target = $asteroidTypes[array_rand($asteroidTypes)];
+
+            if (random_int(1, 100) <= 20) {
+                echo "Mining team explored a {$target} asteroid but found nothing.\n";
+                continue;
+            }
+
+            $yield = random_int(5, 20);
+            $this->resources[$target] += $yield;
+            echo "Mining team brought back {$yield} units of {$target}.\n";
         }
-        foreach ($cost as $res => $amount) {
-            $this->resources[$res] -= $amount;
-        }
-
-        $asteroidTypes = [
-            'iron',
-            'titan',
-            'silica',
-            'copper',
-            'water',
-            'uran_deuterium',
-        ];
-
-        $target = $asteroidTypes[array_rand($asteroidTypes)];
-
-        // 20% chance to find nothing
-        if (random_int(1, 100) <= 20) {
-            echo "Mining team explored a {$target} asteroid but found nothing.\n";
-            return;
-        }
-
-        $yield = random_int(5, 20);
-        $this->resources[$target] += $yield;
-        echo "Mining team brought back {$yield} units of {$target}.\n";
     }
 
     public function getResources(): array
     {
         return $this->resources;
+    }
+
+    public function getMiningTeams(): int
+    {
+        return $this->miningTeams;
+    }
+
+    public function getFinances(): int
+    {
+        return $this->finances;
+    }
+
+    public function recruitTeam(): bool
+    {
+        if ($this->finances < self::TEAM_COST) {
+            return false;
+        }
+
+        $this->finances -= self::TEAM_COST;
+        $this->miningTeams++;
+        return true;
     }
 }


### PR DESCRIPTION
## Summary
- add finances and mining team management to `ResourceAgent`
- persist game state with PHP sessions
- display finances and mining teams in station overview
- allow recruiting new mining teams from the overview

## Testing
- `php -l src/Modules/ResourceModule/ResourceAgent.php` *(fails: php not installed)*
- `composer --version` *(fails: composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866ddde62dc83339d75f112d85637cc